### PR TITLE
Enforce env-based security for AI orchestrator and JWT auth

### DIFF
--- a/services/backend/src/services/ai_orchestrator.py
+++ b/services/backend/src/services/ai_orchestrator.py
@@ -24,10 +24,16 @@ except ImportError:
 
 class AIOrchestrator:
     """AI Orchestrator for managing multiple AI providers and integrations"""
-    
+
     def __init__(self):
-        self.encryption_key = os.getenv("ENCRYPTION_KEY", Fernet.generate_key())
-        self.cipher_suite = Fernet(self.encryption_key)
+        key = os.getenv("ENCRYPTION_KEY")
+        if not key:
+            raise RuntimeError("ENCRYPTION_KEY environment variable must be set for secure operation")
+        try:
+            self.encryption_key = key.encode() if isinstance(key, str) else key
+            self.cipher_suite = Fernet(self.encryption_key)
+        except Exception as e:  # pragma: no cover - defensive
+            raise ValueError("Invalid ENCRYPTION_KEY: must be a 32 urlsafe base64-encoded key") from e
         self.providers = {}
         self.integrations = {}
         self.mcp_tools = {}


### PR DESCRIPTION
## Summary
- require `ENCRYPTION_KEY` for AI orchestrator and validate key format
- implement JWT token verification using python-jose in AI API routes
- remove unused imports from AI routes for cleaner dependency surface

## Testing
- `python -m py_compile services/backend/src/api/ai_routes.py services/backend/src/services/ai_orchestrator.py`
- `PYTHONPATH=services/backend pytest` *(fails: ImportError: cannot import name 'create_app' from 'src.main'; scripts/test_mongodb_connection.py; services/testing/test_routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eff56654832fa9415fb8c4986b48