### PR TITLE
Potential fix for code scanning alert no. 94: Uncontrolled data used in path expression

### DIFF
--- a/core-services/link-ai-core/backend/services/mcp-server/main.py
+++ b/core-services/link-ai-core/backend/services/mcp-server/main.py
@@ -358,9 +358,15 @@ class MCPServer:
         path = args.get("path")
         language = args.get("language", "auto")
         
+        # Define a safe base directory for all file operations
+        BASE_DIR = os.path.abspath("./workspaces")  # change as needed
         try:
-            # Basic code analysis
-            full_path = Path(path)
+            # Compute full path and normalize
+            requested_path = os.path.normpath(os.path.join(BASE_DIR, path))
+            # Check containment: must start with BASE_DIR and path must not escape
+            if not requested_path.startswith(BASE_DIR):
+                return {"error": "Access to this path is not allowed."}
+            full_path = Path(requested_path)
             if not full_path.exists():
                 return {"error": f"Path not found: {path}"}
             


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/94](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/94)

To fix this issue, you must validate user-controlled paths before accessing any files or directories on disk. The best way to do this in your context is to restrict file access to a safe base directory. For every user-provided path, construct the full path using `os.path.join`, normalize it using `os.path.normpath` or `os.path.realpath`, and then check that the normalized path is still inside the intended base directory. Only then should you proceed with any file or directory operations.

In this file, identify the regions in `tool_analyze_code` (lines 356—389) where the path is taken from user input, and add appropriate checks. You may need to define a safe base directory for code analysis (for example, `"./workspaces"` or a configurable variable). If the path is not valid, return an error without performing any file action. You may also want to define the base path as a class attribute (on `MCPServer`) for easier future extension, but if making changes outside this code block isn't permitted, just declare it locally in the method.

You will need the `os` module (already imported), and possibly to adjust how you pass/resolve paths in `Path`. Ensure that you reject any path that could escape your desired directory containment. You do not need additional third-party dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
