### PR TITLE
🎨 Palette: Add loading state to Create RAG Index button

### DIFF
--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -14,6 +14,7 @@ export default function TopBar() {
       } else updateTask(id, { progress: p });
     }, 250);
   };
+  const isIngesting = tasks.some((t) => t.status === "running");
   return (
     <div className="topbar">
       <div className="title">Craft IDE</div>
@@ -27,8 +28,8 @@ export default function TopBar() {
         อ่าน
       </button>
       <div style={{ marginLeft: "auto" }} />
-      <button className="btn primary" onClick={startIngest}>
-        สร้างดัชนี RAG
+      <button className="btn primary" onClick={startIngest} disabled={isIngesting}>
+        {isIngesting ? "กำลังสร้าง..." : "สร้างดัชนี RAG"}
       </button>
       {tasks.slice(-1).map((t) => (
         <span key={t.id} className="badge" style={{ marginLeft: 8 }}>


### PR DESCRIPTION
This change adds a loading state to the "Create RAG Index" button. When the button is clicked, it becomes disabled and its text changes to "Creating..." to provide immediate feedback to the user and prevent multiple clicks.

---
*PR created automatically by Jules for task [6584210957366555594](https://jules.google.com/task/6584210957366555594) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a loading state to the "Create RAG Index" button to provide immediate feedback and prevent duplicate starts. The button is disabled and its label changes to "Creating..." while an ingest task is running.

<sup>Written for commit 56db2d92865ea0d46a2d4db66bdd15ca146def64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

