### PR TITLE
Migrate AI Infrastructure to Asynchronous Architecture

### DIFF
--- a/.github/workflows/version-managment.yml
+++ b/.github/workflows/version-managment.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'pnpm'
+          node-version: '20'
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/apps/backend/api/chat_routes.py
+++ b/apps/backend/api/chat_routes.py
@@ -19,7 +19,7 @@ async def chat_with_provider(request: ChatRequest):
     """
     try:
         client = get_client()
-        response = client.generate_response(
+        response = await client.generate_response(
             provider=request.provider,
             messages=request.messages,
             model=request.model,

--- a/apps/backend/cli_tools/ai_enhanced_chat_app.py
+++ b/apps/backend/cli_tools/ai_enhanced_chat_app.py
@@ -604,19 +604,6 @@ Please analyze and answer the above question based on the file system data.
             messages.append({"role": "user", "content": analysis_prompt})
 
             # Call the unified client
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-
-            if loop.is_running():
-                # Should not happen in threading.Thread background task, but for safety:
-                import concurrent.futures
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    result = executor.submit(asyncio.run, self.ai_client.generate_response(self.ai_provider, messages)).result()
-            else:
-                result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             if result and result.get('success'):
                 self.add_message("ai", result.get('content', 'No content received.'), "ai")

--- a/apps/backend/cli_tools/ai_enhanced_chat_app.py
+++ b/apps/backend/cli_tools/ai_enhanced_chat_app.py
@@ -604,7 +604,19 @@ Please analyze and answer the above question based on the file system data.
             messages.append({"role": "user", "content": analysis_prompt})
 
             # Call the unified client
-            result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            if loop.is_running():
+                # Should not happen in threading.Thread background task, but for safety:
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    result = executor.submit(asyncio.run, self.ai_client.generate_response(self.ai_provider, messages)).result()
+            else:
+                result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             if result and result.get('success'):
                 self.add_message("ai", result.get('content', 'No content received.'), "ai")
@@ -871,7 +883,18 @@ Task: {query}
             messages.append({"role": "user", "content": analysis_prompt})
 
             # Call unified client
-            result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    result = executor.submit(asyncio.run, self.ai_client.generate_response(self.ai_provider, messages)).result()
+            else:
+                result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             # Update UI with result
             self.ai_display.config(state=tk.NORMAL)
@@ -904,7 +927,18 @@ Task: {query}
         """Clean up and close the application."""
         try:
             # Shutdown AI client
-            asyncio.run(self.ai_client.shutdown())
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    executor.submit(asyncio.run, self.ai_client.shutdown()).result()
+            else:
+                asyncio.run(self.ai_client.shutdown())
         except Exception:
             pass
         self.root.destroy()

--- a/apps/backend/cli_tools/ai_enhanced_chat_app.py
+++ b/apps/backend/cli_tools/ai_enhanced_chat_app.py
@@ -11,6 +11,7 @@ from tkinter import ttk, scrolledtext, filedialog, messagebox
 import json
 import threading
 import time
+import asyncio
 from datetime import datetime
 from pathlib import Path
 import os
@@ -25,7 +26,7 @@ def add_project_root_to_path():
 
 add_project_root_to_path()
 
-from mcp.file_system_analyzer import FileSystemMCPTool
+from core.file_system_analyzer import FileSystemMCPTool
 from utils.unified_ai_client import get_client
 
 class AIEnhancedChatApp:
@@ -70,6 +71,9 @@ class AIEnhancedChatApp:
         self.setup_ui()
         self.setup_styles()
         
+        # Cleanup on close
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+
         # Welcome message
         self.add_system_message("🚀 Welcome to the AI-Enhanced File System MCP Chat!")
         self.add_system_message("💡 New features:\n• 🤖 AI file system analysis\n• 📊 Smart analysis\n• 💡 AI recommendations\n• 🎯 Advanced search")
@@ -600,7 +604,7 @@ Please analyze and answer the above question based on the file system data.
             messages.append({"role": "user", "content": analysis_prompt})
 
             # Call the unified client
-            result = self.ai_client.generate_response(self.ai_provider, messages)
+            result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             if result and result.get('success'):
                 self.add_message("ai", result.get('content', 'No content received.'), "ai")
@@ -867,7 +871,7 @@ Task: {query}
             messages.append({"role": "user", "content": analysis_prompt})
 
             # Call unified client
-            result = self.ai_client.generate_response(self.ai_provider, messages)
+            result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             # Update UI with result
             self.ai_display.config(state=tk.NORMAL)
@@ -896,6 +900,15 @@ Task: {query}
 
         return True
 
+    def on_close(self):
+        """Clean up and close the application."""
+        try:
+            # Shutdown AI client
+            asyncio.run(self.ai_client.shutdown())
+        except Exception:
+            pass
+        self.root.destroy()
+
 def main():
     """Main function to run the application."""
     root = tk.Tk()
@@ -913,4 +926,3 @@ def main():
 
 if __name__ == "__main__":
     main()
->>>>>>> REPLACE

--- a/apps/backend/cli_tools/ai_enhanced_chat_app.py
+++ b/apps/backend/cli_tools/ai_enhanced_chat_app.py
@@ -870,17 +870,6 @@ Task: {query}
             messages.append({"role": "user", "content": analysis_prompt})
 
             # Call unified client
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-
-            if loop.is_running():
-                import concurrent.futures
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    result = executor.submit(asyncio.run, self.ai_client.generate_response(self.ai_provider, messages)).result()
-            else:
                 result = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             # Update UI with result

--- a/apps/backend/cli_tools/unified_chat_app.py
+++ b/apps/backend/cli_tools/unified_chat_app.py
@@ -761,18 +761,13 @@ TASK: Analyze the file system data above and answer the user's question. Be spec
                 {"role": "user", "content": user_prompt}
             ]
 
+            loop = asyncio.new_event_loop()
             try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-
-            if loop.is_running():
-                import concurrent.futures
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    response = executor.submit(asyncio.run, self.ai_client.generate_response(self.ai_provider, messages)).result()
-            else:
-                response = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
+                response = loop.run_until_complete(
+                    self.ai_client.generate_response(self.ai_provider, messages)
+                )
+            finally:
+                loop.close()
 
             if response and response.get('success'):
                 ai_response = response.get('content', 'Could not process')

--- a/apps/backend/cli_tools/unified_chat_app.py
+++ b/apps/backend/cli_tools/unified_chat_app.py
@@ -9,6 +9,7 @@ from tkinter import ttk, scrolledtext, filedialog, messagebox
 import json
 import threading
 import time
+import asyncio
 import subprocess
 import os
 import sys
@@ -24,7 +25,7 @@ def add_project_root_to_path():
 
 add_project_root_to_path()
 
-from mcp.file_system_analyzer import FileSystemMCPTool
+from core.file_system_analyzer import FileSystemMCPTool
 from utils.unified_ai_client import get_client
 
 class UnifiedChatApp:
@@ -67,6 +68,9 @@ class UnifiedChatApp:
         self.setup_ui()
         self.setup_styles()
         
+        # Cleanup on close
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+
         # Auto-start services
         self.auto_start_services()
         
@@ -757,7 +761,7 @@ TASK: Analyze the file system data above and answer the user's question. Be spec
                 {"role": "user", "content": user_prompt}
             ]
 
-            response = self.ai_client.generate_response(self.ai_provider, messages)
+            response = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             if response and response.get('success'):
                 ai_response = response.get('content', 'Could not process')
@@ -1017,6 +1021,15 @@ Models: Available for AI analysis
 • Right-click to copy text.
         """
         self.add_system_message(help_text)
+
+    def on_close(self):
+        """Clean up and close the application."""
+        try:
+            # Shutdown AI client
+            asyncio.run(self.ai_client.shutdown())
+        except Exception:
+            pass
+        self.root.destroy()
 
 def main():
     """Main function."""

--- a/apps/backend/cli_tools/unified_chat_app.py
+++ b/apps/backend/cli_tools/unified_chat_app.py
@@ -761,7 +761,18 @@ TASK: Analyze the file system data above and answer the user's question. Be spec
                 {"role": "user", "content": user_prompt}
             ]
 
-            response = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    response = executor.submit(asyncio.run, self.ai_client.generate_response(self.ai_provider, messages)).result()
+            else:
+                response = asyncio.run(self.ai_client.generate_response(self.ai_provider, messages))
 
             if response and response.get('success'):
                 ai_response = response.get('content', 'Could not process')
@@ -1026,7 +1037,18 @@ Models: Available for AI analysis
         """Clean up and close the application."""
         try:
             # Shutdown AI client
-            asyncio.run(self.ai_client.shutdown())
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    executor.submit(asyncio.run, self.ai_client.shutdown()).result()
+            else:
+                asyncio.run(self.ai_client.shutdown())
         except Exception:
             pass
         self.root.destroy()

--- a/apps/backend/core/ai_orchestrator.py
+++ b/apps/backend/core/ai_orchestrator.py
@@ -157,7 +157,7 @@ class AIOrchestrator:
                 "message": f"Failed to remove provider: {str(e)}"
             }
     
-    def test_provider(self, user_id: str, provider: str) -> Dict[str, Any]:
+    async def test_provider(self, user_id: str, provider: str) -> Dict[str, Any]:
         """Test a provider connection using the UnifiedAIClient."""
         if not self.ai_client:
             return {"success": False, "message": "AI Client not initialized."}
@@ -171,7 +171,7 @@ class AIOrchestrator:
             test_messages = [{"role": "user", "content": "Hello"}]
             
             # The unified client is initialized with config, so we just call it.
-            result = self.ai_client.generate_response(provider, test_messages, max_tokens=10)
+            result = await self.ai_client.generate_response(provider, test_messages, max_tokens=10)
 
             if result and result.get('success'):
                 return {"success": True, "details": {"status": "connected", "response": result.get('content')}}
@@ -182,7 +182,7 @@ class AIOrchestrator:
         except Exception as e:
             return {"success": False, "message": f"Failed to test provider: {str(e)}"}
 
-    def create_completion(
+    async def create_completion(
         self,
         user_id: str,
         prompt: str,
@@ -218,7 +218,7 @@ class AIOrchestrator:
             for provider_name in user_providers.keys():
                 try:
                     # The unified client handles the authentication and provider logic
-                    result = self.ai_client.generate_response(provider_name, messages, **kwargs)
+                    result = await self.ai_client.generate_response(provider_name, messages, **kwargs)
                     
                     if result and result.get('success'):
                         # Track usage
@@ -241,7 +241,7 @@ class AIOrchestrator:
         except Exception as e:
             return {"success": False, "message": f"Failed to create completion: {str(e)}"}
     
-    def analyze_content(
+    async def analyze_content(
         self,
         user_id: str,
         content: str,
@@ -264,7 +264,7 @@ class AIOrchestrator:
                 }
             
             # Use completion to analyze
-            result = self.create_completion(
+            result = await self.create_completion(
                 user_id=user_id,
                 prompt=prompt,
                 max_tokens=2000,

--- a/apps/backend/core/ai_orchestrator.py
+++ b/apps/backend/core/ai_orchestrator.py
@@ -171,7 +171,11 @@ class AIOrchestrator:
             test_messages = [{"role": "user", "content": "Hello"}]
             
             # The unified client is initialized with config, so we just call it.
-            result = await self.ai_client.generate_response(provider, test_messages, max_tokens=10)
+            provider_config = user_providers.get(provider, {})
+            test_kwargs = {"max_tokens": 10, **provider_config.get("config", {})}
+            if provider_config.get("model"):
+                test_kwargs["model"] = provider_config["model"]
+            result = await self.ai_client.generate_response(provider, test_messages, **test_kwargs)
 
             if result and result.get('success'):
                 return {"success": True, "details": {"status": "connected", "response": result.get('content')}}

--- a/apps/backend/core/ai_orchestrator.py
+++ b/apps/backend/core/ai_orchestrator.py
@@ -222,7 +222,11 @@ class AIOrchestrator:
             for provider_name in user_providers.keys():
                 try:
                     # The unified client handles the authentication and provider logic
-                    result = await self.ai_client.generate_response(provider_name, messages, **kwargs)
+                    provider_config = user_providers.get(provider_name, {})
+                    provider_kwargs = {**provider_config.get("config", {}), **kwargs}
+                    if not model and provider_config.get("model"):
+                        provider_kwargs["model"] = provider_config["model"]
+                    result = await self.ai_client.generate_response(provider_name, messages, **provider_kwargs)
                     
                     if result and result.get('success'):
                         # Track usage

--- a/apps/backend/core/rag_system.py
+++ b/apps/backend/core/rag_system.py
@@ -119,7 +119,7 @@ class EmbeddingProvider:
             return False
         try:
             # A simple embedding call to test the connection.
-            result = self.ai_client.embed(self.provider_type, "test", model=self.model_name)
+            result = await self.ai_client.embed(self.provider_type, "test", model=self.model_name)
             return result.get('success', False)
         except Exception as e:
             logger.error(f"❌ Connection test failed for {self.provider_type}: {e}")
@@ -140,7 +140,7 @@ class EmbeddingProvider:
             return None
 
         try:
-            result = self.ai_client.embed(self.provider_type, text, model=self.model_name)
+            result = await self.ai_client.embed(self.provider_type, text, model=self.model_name)
             if result and result.get('success'):
                 return result.get('embedding')
             else:
@@ -959,7 +959,15 @@ class RAGSystem:
                 cached_result = self.cache.get(cache_key)
                 if cached_result:
                     logger.info("✅ Using result from cache")
-                    return [SearchResult(**json.loads(item)) for item in json.loads(cached_result)]
+                    cached_data = json.loads(cached_result)
+                    results = []
+                    for item in cached_data:
+                        doc_data = item['document']
+                        if doc_data.get('created_at'):
+                            doc_data['created_at'] = datetime.fromisoformat(doc_data['created_at'])
+                        doc = Document(**doc_data)
+                        results.append(SearchResult(document=doc, score=item['score'], relevance=item['relevance']))
+                    return results
             
             # Create query embedding
             query_embedding = await self.embedding_provider.get_embedding(query)
@@ -973,7 +981,14 @@ class RAGSystem:
             # Cache results
             if use_cache and results:
                 cache_key = f"search:{hashlib.md5(query.encode()).hexdigest()}"
-                cache_data = json.dumps([asdict(result) for result in results])
+
+                # Custom JSON serializer for datetime
+                def datetime_serializer(obj):
+                    if isinstance(obj, datetime):
+                        return obj.isoformat()
+                    raise TypeError(f"Type {type(obj)} not serializable")
+
+                cache_data = json.dumps([asdict(result) for result in results], default=datetime_serializer)
                 self.cache.setex(cache_key, 1800, cache_data)  # Cache for 30 minutes
             
             return results
@@ -1096,7 +1111,7 @@ Answer:
             # Use a default model from config if available, otherwise let the strategy decide
             model = self.config.get(f"{provider}_model")
             
-            result = self.ai_client.generate_response(provider, messages, model=model)
+            result = await self.ai_client.generate_response(provider, messages, model=model)
 
             if result and result.get('success'):
                 return result.get('content', 'No content received.')

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -3,14 +3,28 @@ MCP AI Orchestrator - Main Entry Point.
 """
 
 import uvicorn
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup: Nothing to do for now
+    yield
+    # Shutdown: Close AI client connections
+    try:
+        from utils.unified_ai_client import get_client
+        client = get_client()
+        await client.shutdown()
+    except Exception as e:
+        print(f"Error during AI client shutdown: {e}")
 
 # Create FastAPI app for MCP orchestrator
 app = FastAPI(
     title="MCP AI Orchestrator",
     description="AI-powered MCP (Model Context Protocol) Orchestrator",
     version="2.2.0",
+    lifespan=lifespan,
 )
 
 # Add CORS middleware

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -13,11 +13,12 @@ async def lifespan(app: FastAPI):
     yield
     # Shutdown: Close AI client connections
     try:
-        from utils.unified_ai_client import get_client
+        from .utils.unified_ai_client import get_client
         client = get_client()
         await client.shutdown()
     except Exception as e:
-        print(f"Error during AI client shutdown: {e}")
+        import logging
+        logging.getLogger(__name__).warning(f"Error during AI client shutdown: {e}")
 
 # Create FastAPI app for MCP orchestrator
 app = FastAPI(

--- a/apps/backend/utils/langchain_adapter.py
+++ b/apps/backend/utils/langchain_adapter.py
@@ -6,6 +6,7 @@ This module provides a wrapper class that makes the UnifiedAIClient compatible
 with the LangChain library, specifically for use with frameworks like CrewAI.
 """
 
+import asyncio
 from typing import Any, List, Mapping, Optional, Dict
 from langchain_core.language_models.llms import LLM
 
@@ -47,7 +48,30 @@ class UnifiedAIClientLangChainAdapter(LLM):
         **kwargs: Any,
     ) -> str:
         """
-        Makes a call to the UnifiedAIClient.
+        Makes a synchronous call to the UnifiedAIClient.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        if loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(asyncio.run, self._acall(prompt, stop, **kwargs))
+                return future.result()
+        else:
+            return loop.run_until_complete(self._acall(prompt, stop, **kwargs))
+
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        """
+        Makes an asynchronous call to the UnifiedAIClient.
 
         This method is the core of the LangChain integration. It takes a prompt,
         sends it to the configured provider via the UnifiedAIClient, and returns
@@ -72,7 +96,7 @@ class UnifiedAIClientLangChainAdapter(LLM):
         if self.model:
             api_kwargs['model'] = self.model
 
-        response = self.client.generate_response(self.provider, messages, **api_kwargs)
+        response = await self.client.generate_response(self.provider, messages, **api_kwargs)
 
         if response and response.get('success'):
             return response.get('content', '')

--- a/apps/backend/utils/langchain_adapter.py
+++ b/apps/backend/utils/langchain_adapter.py
@@ -96,7 +96,7 @@ class UnifiedAIClientLangChainAdapter(LLM):
         if self.model:
             api_kwargs['model'] = self.model
 
-        response = await self.client.generate_response(self.provider, messages, **api_kwargs)
+        response = await self.client.generate_response(self.provider, messages, **kwargs, **api_kwargs)
 
         if response and response.get('success'):
             return response.get('content', '')

--- a/apps/backend/utils/test_unified_ai_client.py
+++ b/apps/backend/utils/test_unified_ai_client.py
@@ -1,6 +1,7 @@
 import pytest
-from unittest.mock import patch, MagicMock
-from .unified_ai_client import GoogleStrategy
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+from .unified_ai_client import GoogleStrategy, OpenAIStrategy, OllamaStrategy
 
 @patch('google.generativeai.configure')
 def test_google_strategy_initialization(mock_configure):
@@ -9,23 +10,24 @@ def test_google_strategy_initialization(mock_configure):
     mock_configure.assert_called_once_with(api_key='test_api_key')
     assert strategy.model is not None
 
+@pytest.mark.asyncio
 @patch('google.generativeai.GenerativeModel')
 @patch('google.generativeai.configure')
-def test_google_strategy_generate_response_success(mock_configure, mock_generative_model):
+async def test_google_strategy_generate_response_success(mock_configure, mock_generative_model):
     """Tests a successful generate_response call with a per-request model."""
     mock_api_response = MagicMock()
     mock_api_response.text = 'Test response'
 
     # Mock the return value of the GenerativeModel constructor
     mock_model_instance = MagicMock()
-    mock_model_instance.generate_content.return_value = mock_api_response
+    mock_model_instance.generate_content_async = AsyncMock(return_value=mock_api_response)
     mock_generative_model.return_value = mock_model_instance
 
     strategy = GoogleStrategy(api_key='test_api_key', model='gemini-1.5-flash')
     messages = [{'role': 'user', 'content': 'Hello'}]
 
     # Call with a different model
-    response = strategy.generate_response(messages, model='gemini-pro')
+    response = await strategy.generate_response(messages, model='gemini-pro')
 
     # Verify that the correct model was used
     mock_generative_model.assert_called_with('gemini-pro')
@@ -34,40 +36,86 @@ def test_google_strategy_generate_response_success(mock_configure, mock_generati
     assert response['content'] == 'Test response'
     assert response['metadata']['model'] == 'gemini-pro'
 
+@pytest.mark.asyncio
 @patch('google.generativeai.GenerativeModel')
 @patch('google.generativeai.configure')
-def test_google_strategy_generate_response_error(mock_configure, mock_model):
+async def test_google_strategy_generate_response_error(mock_configure, mock_model):
     """Tests error handling in the generate_response method."""
-    mock_model.return_value.generate_content.side_effect = Exception('API Error')
+    mock_model.return_value.generate_content_async.side_effect = Exception('API Error')
 
     strategy = GoogleStrategy(api_key='test_api_key', model='gemini-1.5-flash')
     messages = [{'role': 'user', 'content': 'Hello'}]
-    response = strategy.generate_response(messages)
+    response = await strategy.generate_response(messages)
 
     assert response['success'] is False
     assert response['error'] == 'API Error'
 
-@patch('google.generativeai.embed_content')
+@pytest.mark.asyncio
+@patch('google.generativeai.embed_content_async')
 @patch('google.generativeai.configure')
-def test_google_strategy_embed_success(mock_configure, mock_embed_content):
+async def test_google_strategy_embed_success(mock_configure, mock_embed_content):
     """Tests a successful embed call."""
     mock_embed_content.return_value = {'embedding': [0.1, 0.2, 0.3]}
 
     strategy = GoogleStrategy(api_key='test_api_key')
-    response = strategy.embed('some text')
+    response = await strategy.embed('some text')
 
     assert response['success'] is True
     assert response['provider'] == 'google'
     assert response['embedding'] == [0.1, 0.2, 0.3]
 
-@patch('google.generativeai.embed_content')
+@pytest.mark.asyncio
+@patch('google.generativeai.embed_content_async')
 @patch('google.generativeai.configure')
-def test_google_strategy_embed_error(mock_configure, mock_embed_content):
+async def test_google_strategy_embed_error(mock_configure, mock_embed_content):
     """Tests error handling in the embed method."""
     mock_embed_content.side_effect = Exception('Embedding Error')
 
     strategy = GoogleStrategy(api_key='test_api_key')
-    response = strategy.embed('some text')
+    response = await strategy.embed('some text')
 
     assert response['success'] is False
     assert response['error'] == 'Embedding Error'
+
+@pytest.mark.asyncio
+@patch('openai.resources.chat.completions.AsyncCompletions.create', new_callable=AsyncMock)
+async def test_openai_strategy_generate_response_success(mock_create):
+    """Tests a successful OpenAI generate_response call."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = 'OpenAI response'
+    mock_response.choices[0].finish_reason = 'stop'
+    mock_response.model = 'gpt-4o-mini'
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 20
+    mock_response.usage.total_tokens = 30
+    mock_create.return_value = mock_response
+
+    strategy = OpenAIStrategy(api_key='test_key')
+    messages = [{'role': 'user', 'content': 'Hello'}]
+    response = await strategy.generate_response(messages)
+
+    assert response['success'] is True
+    assert response['content'] == 'OpenAI response'
+    assert response['metadata']['usage']['total_tokens'] == 30
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_ollama_strategy_generate_response_success(mock_post):
+    """Tests a successful Ollama generate_response call."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'response': 'Ollama response',
+        'model': 'llama3',
+        'total_duration': 1000
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_post.return_value = mock_response
+
+    strategy = OllamaStrategy(base_url='http://localhost:11434')
+    messages = [{'role': 'user', 'content': 'Hello'}]
+    response = await strategy.generate_response(messages)
+
+    assert response['success'] is True
+    assert response['content'] == 'Ollama response'
+    assert response['metadata']['model'] == 'llama3'

--- a/apps/backend/utils/unified_ai_client.py
+++ b/apps/backend/utils/unified_ai_client.py
@@ -66,8 +66,8 @@ class AIProviderStrategy(ABC):
 
 class OpenAIStrategy(AIProviderStrategy):
     """Strategy for interacting with OpenAI models."""
-    def __init__(self, api_key: str, base_url: Optional[str] = None, model: str = "gpt-4o-mini", temperature: float = 0.7, max_tokens: int = 2000):
-        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+    def __init__(self, api_key: str, base_url: Optional[str] = None, model: str = "gpt-4o-mini", temperature: float = 0.7, max_tokens: int = 2000, timeout: float = 60.0, max_retries: int = 3):
+        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout, max_retries=max_retries)
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -167,11 +167,15 @@ class OllamaStrategy(AIProviderStrategy):
                     response = await self.client.post(f"{self.base_url}/api/generate", json=payload)
                     response.raise_for_status()
                     break
-                except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                except (httpx.ConnectError, httpx.TimeoutException) as e:
                     if attempt == max_retries - 1:
+                        logger.error(f"❌ Ollama connection failed after {max_retries} attempts: {str(e)}")
                         raise
-                    logger.warning(f"⚠️ Ollama attempt {attempt + 1} failed, retrying...: {str(e)}")
-                    await asyncio.sleep(1)
+                    logger.warning(f"⚠️ Ollama connection attempt {attempt + 1} failed, retrying...: {str(e)}")
+                    await asyncio.sleep(2**attempt) # Exponential backoff
+                except httpx.HTTPStatusError as e:
+                    logger.error(f"❌ Ollama returned HTTP error: {e.response.status_code} - {e.response.text}")
+                    return {'success': False, 'error': f"HTTP {e.response.status_code}: {e.response.text}"}
 
             result = response.json()
             logger.info(f"✅ Received response from {payload['model']}.")

--- a/apps/backend/utils/unified_ai_client.py
+++ b/apps/backend/utils/unified_ai_client.py
@@ -8,10 +8,11 @@ a Strategy design pattern to handle the differences between provider APIs.
 """
 
 import os
-import requests
+import httpx
 import json
 import logging
-import openai
+import asyncio
+from openai import AsyncOpenAI
 import google.generativeai as genai
 from abc import ABC, abstractmethod
 from typing import Dict, Any, List, Optional
@@ -29,7 +30,7 @@ class AIProviderStrategy(ABC):
     Abstract base class for AI provider strategies.
     """
     @abstractmethod
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         """
         Generates a response from the AI provider.
 
@@ -43,7 +44,7 @@ class AIProviderStrategy(ABC):
         pass
 
     @abstractmethod
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         """
         Generates an embedding for a given text.
 
@@ -56,21 +57,26 @@ class AIProviderStrategy(ABC):
         """
         pass
 
+    @abstractmethod
+    async def close(self):
+        """Closes the underlying client/session."""
+        pass
+
 # --- Concrete Strategies ---
 
 class OpenAIStrategy(AIProviderStrategy):
     """Strategy for interacting with OpenAI models."""
     def __init__(self, api_key: str, base_url: Optional[str] = None, model: str = "gpt-4o-mini", temperature: float = 0.7, max_tokens: int = 2000):
-        self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
         logger.info(f"OpenAIStrategy initialized for model {self.model}")
 
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         """Generates a response using the OpenAI API."""
         try:
-            response = self.client.chat.completions.create(
+            response = await self.client.chat.completions.create(
                 model=kwargs.get('model', self.model),
                 messages=messages,
                 max_tokens=kwargs.get('max_tokens', self.max_tokens),
@@ -94,11 +100,11 @@ class OpenAIStrategy(AIProviderStrategy):
             logger.error(f"❌ OpenAI API error: {str(e)}")
             return {'success': False, 'error': str(e)}
 
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         """Generates an embedding using the OpenAI API."""
         try:
             model_to_use = model or "text-embedding-3-small"
-            response = self.client.embeddings.create(
+            response = await self.client.embeddings.create(
                 model=model_to_use,
                 input=text
             )
@@ -118,17 +124,20 @@ class OpenAIStrategy(AIProviderStrategy):
             logger.error(f"❌ OpenAI embedding error: {str(e)}")
             return {'success': False, 'error': str(e)}
 
+    async def close(self):
+        """Closes the OpenAI client."""
+        await self.client.close()
+
 
 class OllamaStrategy(AIProviderStrategy):
     """Strategy for interacting with Ollama models."""
     def __init__(self, base_url: str = "http://localhost:11434", model: str = "deepseek-coder:6.7b-instruct", timeout: int = 30):
         self.base_url = base_url.rstrip('/')
         self.model = model
-        self.session = requests.Session()
-        self.session.timeout = timeout
+        self.client = httpx.AsyncClient(timeout=timeout)
         logger.info(f"OllamaStrategy initialized for model {self.model} at {self.base_url}")
 
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         """
         Generates a response from an Ollama server.
         It uses the last message as the main prompt and can handle a system prompt.
@@ -150,8 +159,19 @@ class OllamaStrategy(AIProviderStrategy):
                 payload["system"] = system_prompt
 
             logger.info(f"🤖 Sending prompt to Ollama model {payload['model']}...")
-            response = self.session.post(f"{self.base_url}/api/generate", json=payload)
-            response.raise_for_status()  # Raise an exception for bad status codes
+
+            # Implementation of retry handling
+            max_retries = 3
+            for attempt in range(max_retries):
+                try:
+                    response = await self.client.post(f"{self.base_url}/api/generate", json=payload)
+                    response.raise_for_status()
+                    break
+                except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                    if attempt == max_retries - 1:
+                        raise
+                    logger.warning(f"⚠️ Ollama attempt {attempt + 1} failed, retrying...: {str(e)}")
+                    await asyncio.sleep(1)
 
             result = response.json()
             logger.info(f"✅ Received response from {payload['model']}.")
@@ -166,16 +186,16 @@ class OllamaStrategy(AIProviderStrategy):
                     'eval_count': result.get('eval_count'),
                 }
             }
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             logger.error(f"❌ An error occurred while communicating with Ollama: {str(e)}")
             return {'success': False, 'error': str(e)}
 
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         """Generates an embedding using the Ollama API."""
         try:
             model_to_use = model or self.model
             logger.info(f"🤖 Generating embedding with Ollama model {model_to_use}...")
-            response = self.session.post(
+            response = await self.client.post(
                 f"{self.base_url}/api/embeddings",
                 json={
                     "model": model_to_use,
@@ -190,17 +210,23 @@ class OllamaStrategy(AIProviderStrategy):
                 'embedding': result.get('embedding'),
                 'metadata': {'model': model_to_use}
             }
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             logger.error(f"❌ Ollama embedding error: {str(e)}")
             return {'success': False, 'error': str(e)}
+
+    async def close(self):
+        """Closes the httpx client."""
+        await self.client.aclose()
 
 
 # Placeholder for other strategies
 class OpenRouterStrategy(AIProviderStrategy):
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         return {"provider": "openrouter", "content": "Not implemented yet"}
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         return {'success': False, 'error': 'Not implemented'}
+    async def close(self):
+        pass
 
 
 class GoogleStrategy(AIProviderStrategy):
@@ -215,7 +241,7 @@ class GoogleStrategy(AIProviderStrategy):
             logger.error(f"❌ Failed to initialize GoogleStrategy: {str(e)}")
             raise
 
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         """Generates a response using the Google Generative AI API."""
         try:
             model_name = kwargs.get('model', self.model_name)
@@ -230,7 +256,7 @@ class GoogleStrategy(AIProviderStrategy):
                 } for msg in messages
             ]
 
-            response = model.generate_content(
+            response = await model.generate_content_async(
                 formatted_messages,
                 generation_config=genai.types.GenerationConfig(
                     # Only one candidate is needed
@@ -253,11 +279,11 @@ class GoogleStrategy(AIProviderStrategy):
             return {'success': False, 'error': str(e)}
 
 
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         """Generates an embedding using the Google Generative AI API."""
         try:
             model_to_use = model or "models/embedding-001"
-            result = genai.embed_content(
+            result = await genai.embed_content_async(
                 model=model_to_use,
                 content=text,
                 task_type="retrieval_document"
@@ -272,25 +298,34 @@ class GoogleStrategy(AIProviderStrategy):
             logger.error(f"❌ Google embedding error: {str(e)}")
             return {'success': False, 'error': str(e)}
 
+    async def close(self):
+        pass
+
 
 
 class AnthropicStrategy(AIProviderStrategy):
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         return {"provider": "anthropic", "content": "Not implemented yet"}
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         return {'success': False, 'error': 'Not implemented'}
+    async def close(self):
+        pass
 
 class DeepSeekStrategy(AIProviderStrategy):
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         return {"provider": "deepseek", "content": "Not implemented yet"}
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         return {'success': False, 'error': 'Not implemented'}
+    async def close(self):
+        pass
 
 class MistralStrategy(AIProviderStrategy):
-    def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         return {"provider": "mistral", "content": "Not implemented yet"}
-    def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         return {'success': False, 'error': 'Not implemented'}
+    async def close(self):
+        pass
 
 
 class UnifiedAIClient:
@@ -340,7 +375,7 @@ class UnifiedAIClient:
         """
         return self._strategies.get(provider_name.lower())
 
-    def generate_response(self, provider: str, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
+    async def generate_response(self, provider: str, messages: List[Dict[str, str]], **kwargs) -> Dict[str, Any]:
         """
         Generates a response using a specified provider.
 
@@ -359,9 +394,9 @@ class UnifiedAIClient:
         if not strategy:
             raise ValueError(f"Provider '{provider}' is not supported or configured.")
 
-        return strategy.generate_response(messages, **kwargs)
+        return await strategy.generate_response(messages, **kwargs)
 
-    def embed(self, provider: str, text: str, model: Optional[str] = None) -> Dict[str, Any]:
+    async def embed(self, provider: str, text: str, model: Optional[str] = None) -> Dict[str, Any]:
         """
         Generates an embedding using a specified provider.
 
@@ -380,7 +415,16 @@ class UnifiedAIClient:
         if not strategy:
             raise ValueError(f"Provider '{provider}' is not supported or configured.")
 
-        return strategy.embed(text, model)
+        return await strategy.embed(text, model)
+
+    async def shutdown(self):
+        """Shuts down all provider strategies and closes their connections."""
+        logger.info("🔌 Shutting down UnifiedAIClient strategies...")
+        for name, strategy in self._strategies.items():
+            try:
+                await strategy.close()
+            except Exception as e:
+                logger.error(f"Error closing strategy {name}: {e}")
 
 # --- Singleton Client Instance ---
 _client_instance = None

--- a/apps/backend/utils/unified_ai_client.py
+++ b/apps/backend/utils/unified_ai_client.py
@@ -429,7 +429,9 @@ class UnifiedAIClient:
                 await strategy.close()
             except Exception as e:
                 logger.error(f"Error closing strategy {name}: {e}")
-
+        self._strategies.clear()
+        global _client_instance
+        _client_instance = None
 # --- Singleton Client Instance ---
 _client_instance = None
 


### PR DESCRIPTION
## **User description**
This PR migrates the core AI infrastructure of the backend from a synchronous to an asynchronous model. 

Key changes include:
- **UnifiedAIClient Migration**: All strategies now use asynchronous clients (AsyncOpenAI, httpx.AsyncClient, and async SDK methods). A `shutdown` method was added to the client and strategies for graceful resource cleanup.
- **Lifecycle Management**: Integrated `UnifiedAIClient.shutdown()` into the FastAPI application's lifespan events and added `on_close` handlers to the Tkinter CLI applications.
- **RAG System Fixes**: Resolved JSON serialization issues in the search result cache by converting `datetime` objects to ISO strings and implementing manual reconstruction logic.
- **Async Interoperability**: Updated the LangChain adapter and CLI tools to safely handle the transition between synchronous and asynchronous contexts using `asyncio.run()` and appropriate event loop management.
- **Robustness**: Added retry logic for the Ollama provider and ensured all internal orchestrator methods are now asynchronous.

The migration was verified using updated `pytest-asyncio` tests and smoke tests for the API and CLI components.

Fixes #169

---
*PR created automatically by Jules for task [11254874292456810152](https://jules.google.com/task/11254874292456810152) started by @billlzzz10*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown and resource cleanup to avoid leaks and handle app/window close gracefully.
  * Fixed cached search serialization/deserialization to preserve timestamps.

* **Chores**
  * Migrated core AI interactions to asynchronous execution to improve responsiveness.
  * Added orderly async shutdown for AI clients and updated adapter/interop paths.

* **Tests**
  * Converted and added async tests covering provider generation and embedding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Move AI requests to async handling and clean up app shutdown**

### What Changed
- AI responses and embeddings now run asynchronously across chat, analysis, search, and provider test flows.
- Desktop chat apps now close AI connections when the window is closed, reducing leftover background processes.
- Ollama calls now retry after connection or timeout failures, and HTTP errors return clearer failure messages.
- Search cache entries now save and restore date values correctly, so cached results still load after reuse.
- Tests were updated to cover the async provider flows and new Ollama/OpenAI behavior.

### Impact
`✅ Faster AI responses`
`✅ Fewer failed Ollama requests`
`✅ Cleaner app shutdown`
`✅ Reliable cached search results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
